### PR TITLE
Fix formatting for `.gitattributes`, add text=auto

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
-/.gitignore		export-ignore
-/.travis.yml 	export-ignore
-/.styleci.yml	export-ignore
-/tests			export-ignore
-/phpunit.xml.dist	export-ignore
-/.gitattributes export-ignore
+* text=auto
+
+/tests              export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.styleci.yml        export-ignore
+.travis.yml         export-ignore
+phpunit.xml.dist    export-ignore


### PR DESCRIPTION
_This PR has no functional changes._

I've just formatted `.gitattributes` a bit 🙂 

And added `* text=auto` for the [standardized end-of-lines](https://git-scm.com/docs/gitattributes#_end_of_line_conversion). 