### PR TITLE
Change required PHP version to 7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+ - Changed minimum required PHP version to 7.1
+ - Downgraded PHPUnit from 8.0 to 7.0 as a result of PHP version change
 
 ## [1.0.2] - 2019-02-23
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         }
     ],
     "require": {
-        "php": "^7.2"
+        "php": "^7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^7.0",
         "orchestra/testbench": "^3.7"
     },
     "autoload": {


### PR DESCRIPTION
Resolves #19 

Went with 7.1 rather than 7.0 to avoid changing any code (function return types in test cases) and because 7.0 is not officially supported any more.