### PR TITLE
Add the DB host to the import command

### DIFF
--- a/src/Snipe.php
+++ b/src/Snipe.php
@@ -109,7 +109,7 @@ class Snipe
         if (! SnipeDatabaseState::$importedDatabase) {
             $dumpfile = config('snipe.snapshot-location');
 
-            exec("mysql -u {$this->getDbUsername()} --password={$this->getDbPassword()} {$this->getDbName()} < {$dumpfile} 2>/dev/null");
+            exec("mysql -h {$this->getDbHost()} -u {$this->getDbUsername()} --password={$this->getDbPassword()} {$this->getDbName()} < {$dumpfile} 2>/dev/null");
 
             SnipeDatabaseState::$importedDatabase = true;
         }


### PR DESCRIPTION
I think this was just a mistake, the host was included on the mysqldump command, but not the mysql import command.

(Thanks for this package by the way, it solves some major headaches for me 😄)