### PR TITLE
Allow Snipe to seed the database after migrating it

### DIFF
--- a/config/snipe.php
+++ b/config/snipe.php
@@ -1,6 +1,28 @@
 <?php
 
 return [
-    'snapshot-location' => __DIR__.'/../snapshots/snipe_snapshot.sql',
-    'snipefile-location' => __DIR__.'/../snapshots/.snipe',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Storage Locations
+    |--------------------------------------------------------------------------
+    | By default, SnipeMigrations will store snipe files and database snapshots
+    | in /vendor/drfraker/snipe-migrations/snapshots. If you would like to
+    | change the location of the files, update the paths below.
+    */
+    'snapshot-location'  => base_path('vendor/drfraker/snipe-migrations/snapshots/') . 'snipe_snapshot.sql',
+    'snipefile-location' => base_path('vendor/drfraker/snipe-migrations/snapshots/') . '.snipe',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Database Seeding
+    |--------------------------------------------------------------------------
+    | By default SnipeMigrations will refresh the database, run all migrations,
+    | and start each test with an empty database. If you would like to seed
+    | the database after refreshing it, enable the setting below. A custom
+    | class can be set, otherwise, the default DatabaseSeeder will run.
+    */
+    'seed-database'      => false,
+    'seed-class'         => 'DatabaseSeeder',
+
 ];

--- a/src/Snipe.php
+++ b/src/Snipe.php
@@ -62,6 +62,13 @@ class Snipe
     {
         Artisan::call('migrate:fresh');
 
+        // Seed the database if required
+        if (config('snipe.seed-database', false)) {
+            Artisan::call('db:seed', [
+                '--class' => config('snipe.seed-class', 'DatabaseSeeder'),
+            ]);
+        }
+
         $storageLocation = config('snipe.snapshot-location');
 
         // Store a snapshot of the db after migrations run.
@@ -82,7 +89,7 @@ class Snipe
                     ->sum(function ($file) {
                         return $file->getMTime();
                     });
-            })->sum();
+            })->sum() + (config('snipe.seed-database', false) ? 1 : -1);
     }
 
     /**

--- a/src/SnipeClearCommand.php
+++ b/src/SnipeClearCommand.php
@@ -6,11 +6,33 @@ use Illuminate\Console\Command;
 
 class SnipeClearCommand extends Command
 {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
     protected $signature = 'snipe:clear';
 
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
     public function handle()
     {
-        @unlink(config('snipe.snipefile-location'));
-        $this->info('Cleared snipe migration snapshot.');
+        $snipefile = config('snipe.snipefile-location');
+
+        if ($snipefile && file_exists($snipefile)) {
+            try {
+                unlink($snipefile);
+                $this->info('Cleared snipe migration snapshot.');
+            } catch (\Exception $exception) {
+                $this->warn("Could not delete snipe migration file: {$exception->getMessage()}");
+            }
+
+            return;
+        }
+
+        $this->info('No Snipe migration snapshot found (it may have been cleared already).');
     }
 }


### PR DESCRIPTION
I often need to seed the database with some basic values before running my tests, and I'm sure this is the case for others too.

I've added a configuration option to allow Snipe to automatically seed the database after refreshing it. If seeding takes place, it will store the seeded data to the snapshot. This can save a lot of time over re-seeding the database at the beginning of every test — in my own testing, I managed to halve the time a test suite took when using this technique.

By default, seeding is switched off. A configuration setting allows for it to be turned on, and you can specify which seed class to use as well.

I also tidied up a couple of small areas of the code as I was going through it.

Let me know what you think!