### PR TITLE
Allow Snipe to seed the database after migrating it and auto-update on seed file change

### DIFF
--- a/config/snipe.php
+++ b/config/snipe.php
@@ -10,8 +10,8 @@ return [
     | in /vendor/drfraker/snipe-migrations/snapshots. If you would like to
     | change the location of the files, update the paths below.
     */
-    'snapshot-location'  => base_path('vendor/drfraker/snipe-migrations/snapshots/') . 'snipe_snapshot.sql',
-    'snipefile-location' => base_path('vendor/drfraker/snipe-migrations/snapshots/') . '.snipe',
+    'snapshot-location'  => base_path('vendor/drfraker/snipe-migrations/snapshots/').'snipe_snapshot.sql',
+    'snipefile-location' => base_path('vendor/drfraker/snipe-migrations/snapshots/').'.snipe',
 
     /*
     |--------------------------------------------------------------------------

--- a/config/snipe.php
+++ b/config/snipe.php
@@ -1,6 +1,28 @@
 <?php
 
 return [
-    'snapshot-location' => __DIR__.'/../snapshots/snipe_snapshot.sql',
-    'snipefile-location' => __DIR__.'/../snapshots/.snipe',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Storage Locations
+    |--------------------------------------------------------------------------
+    | By default, SnipeMigrations will store snipe files and database snapshots
+    | in /vendor/drfraker/snipe-migrations/snapshots. If you would like to
+    | change the location of the files, update the paths below.
+    */
+    'snapshot-location'  => base_path('vendor/drfraker/snipe-migrations/snapshots/') . 'snipe_snapshot.sql',
+    'snipefile-location' => base_path('vendor/drfraker/snipe-migrations/snapshots/') . '.snipe',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Database Seeding
+    |--------------------------------------------------------------------------
+    | By default SnipeMigrations will refresh the database, run all migrations,
+    | and start each test with an empty database. If you would like to seed
+    | the database after refreshing it, enable the setting below. A custom
+    | class can be set, otherwise, the default DatabaseSeeder will run.
+    */
+    'seed-database'      => false,
+    'seed-class'         => 'DatabaseSeeder',
+
 ];

--- a/src/Snipe.php
+++ b/src/Snipe.php
@@ -62,6 +62,13 @@ class Snipe
     {
         Artisan::call('migrate:fresh');
 
+        // Seed the database if required
+        if (config('snipe.seed-database', false)) {
+            Artisan::call('db:seed', [
+                '--class' => config('snipe.seed-class', 'DatabaseSeeder'),
+            ]);
+        }
+
         $storageLocation = config('snipe.snapshot-location');
 
         // Store a snapshot of the db after migrations run.
@@ -82,7 +89,7 @@ class Snipe
                     ->sum(function ($file) {
                         return $file->getMTime();
                     });
-            })->sum();
+            })->sum() + (config('snipe.seed-database', false) ? 1 : -1);
     }
 
     /**

--- a/src/Snipe.php
+++ b/src/Snipe.php
@@ -43,7 +43,6 @@ class Snipe
     protected function databaseFileChanges()
     {
         if (! SnipeDatabaseState::$checkedForDatabaseFileChanges) {
-
             $timeSum = config('snipe.seed-database', false)
                 ? $this->migrationFileTimeSum() + $this->seederFileTimeSum()
                 : $this->migrationFileTimeSum();

--- a/src/SnipeClearCommand.php
+++ b/src/SnipeClearCommand.php
@@ -6,11 +6,33 @@ use Illuminate\Console\Command;
 
 class SnipeClearCommand extends Command
 {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
     protected $signature = 'snipe:clear';
 
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
     public function handle()
     {
-        @unlink(config('snipe.snipefile-location'));
-        $this->info('Cleared snipe migration snapshot.');
+        $snipefile = config('snipe.snipefile-location');
+
+        if ($snipefile && file_exists($snipefile)) {
+            try {
+                unlink($snipefile);
+                $this->info('Cleared snipe migration snapshot.');
+            } catch (\Exception $exception) {
+                $this->warn("Could not delete snipe migration file: {$exception->getMessage()}");
+            }
+
+            return;
+        }
+
+        $this->info('No Snipe migration snapshot found (it may have been cleared already).');
     }
 }

--- a/src/SnipeDatabaseState.php
+++ b/src/SnipeDatabaseState.php
@@ -12,5 +12,5 @@ class SnipeDatabaseState
 {
     public static $importedDatabase = false;
 
-    public static $checkedForMigrationChanges = false;
+    public static $checkedForDatabaseFileChanges = false;
 }


### PR DESCRIPTION
This PR builds on the work already done by @JackWH on #24, and adds logic that it automatically updates the snapshot if `config('snipe.seed-database')` is true and there has been a change to a seed file.

I would have added directly to the existing PR but not sure how to do this or if it is possible. 

Thanks for a great package.