### PR TITLE
Add support for custom binary paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",
-        "orchestra/testbench": "^3.7"
+        "orchestra/testbench": "^3.7",
+        "php-mock/php-mock-mockery": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/config/snipe.php
+++ b/config/snipe.php
@@ -25,7 +25,6 @@ return [
     'seed-database'      => false,
     'seed-class'         => 'DatabaseSeeder',
 
-
     /*
     |--------------------------------------------------------------------------
     | Command Execution

--- a/config/snipe.php
+++ b/config/snipe.php
@@ -25,4 +25,21 @@ return [
     'seed-database'      => false,
     'seed-class'         => 'DatabaseSeeder',
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Command Execution
+    |--------------------------------------------------------------------------
+    | Many systems have the mysql binaries already installed (e.g. Homestead).
+    | In case the binaries lie at a different path or have a special prefix,
+    | as seen in docker-based setups, they can be configured here.
+    |
+    | e.g. 'mysql' => 'docker-compose test_db mysql'
+    */
+
+    'binaries'          => [
+        'mysql'     => 'mysql',
+        'mysqldump' => 'mysqldump',
+    ],
+
 ];

--- a/snapshots/.gitignore
+++ b/snapshots/.gitignore
@@ -1,2 +1,0 @@
-.snipe
-snipe_snapshot.sql

--- a/snapshots/.gitignore
+++ b/snapshots/.gitignore
@@ -1,0 +1,2 @@
+.snipe
+snipe_snapshot.sql

--- a/src/Snipe.php
+++ b/src/Snipe.php
@@ -215,7 +215,7 @@ class Snipe
      * @param  string  $binary
      * @param  string  $command
      */
-    protected function execute(string $binary, string $command)
+    protected function execute($binary, $command)
     {
         exec("{$this->getBinaryPath($binary)} $command");
     }

--- a/src/Snipe.php
+++ b/src/Snipe.php
@@ -74,7 +74,7 @@ class Snipe
         $storageLocation = config('snipe.snapshot-location');
 
         // Store a snapshot of the db after migrations run.
-        exec("mysqldump -h {$this->getDbHost()} -u {$this->getDbUsername()} --password={$this->getDbPassword()} {$this->getDbName()} > {$storageLocation} 2>/dev/null");
+        $this->execute('mysqldump', "-h {$this->getDbHost()} -u {$this->getDbUsername()} --password={$this->getDbPassword()} {$this->getDbName()} > {$storageLocation} 2>/dev/null");
     }
 
     /**
@@ -134,7 +134,7 @@ class Snipe
         if (! SnipeDatabaseState::$importedDatabase) {
             $dumpfile = config('snipe.snapshot-location');
 
-            exec("mysql -h {$this->getDbHost()} -u {$this->getDbUsername()} --password={$this->getDbPassword()} {$this->getDbName()} < {$dumpfile} 2>/dev/null");
+            $this->execute('mysql', "-h {$this->getDbHost()} -u {$this->getDbUsername()} --password={$this->getDbPassword()} {$this->getDbName()} < {$dumpfile} 2>/dev/null");
 
             SnipeDatabaseState::$importedDatabase = true;
         }
@@ -196,5 +196,27 @@ class Snipe
         $connection = $this->getDatabaseConnection();
 
         return config("database.connections.{$connection}.database");
+    }
+
+    /**
+     * Returns the path to the given binary executable.
+     *
+     * @param string $binary
+     * @return string
+     */
+    protected function getBinaryPath($binary)
+    {
+        return config("snipe.binaries.$binary", $binary);
+    }
+
+    /**
+     * Executes the given command.
+     *
+     * @param  string  $binary
+     * @param  string  $command
+     */
+    protected function execute(string $binary, string $command)
+    {
+        exec("{$this->getBinaryPath($binary)} $command");
     }
 }

--- a/tests/SnipeMigrationsTest.php
+++ b/tests/SnipeMigrationsTest.php
@@ -3,17 +3,49 @@
 namespace Drfraker\SnipeMigrations\Tests;
 
 use Drfraker\SnipeMigrations\Snipe;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Artisan;
+use Drfraker\SnipeMigrations\SnipeDatabaseState;
 
 class SnipeMigrationsTest extends TestCase
 {
+    /** @var Snipe */
     protected $snipe;
+
+    /**
+     * The absolute path to the "snapshots" folder
+     * @var
+     */
+    protected $snipeFolder;
+
+    /**
+     * The full path to the snipe_snapshot.sql file
+     * @var string
+     */
+    protected $snapshotFile;
+
+    /**
+     * The full path to the .snip file
+     * @var string
+     */
+    protected $snipeFile;
+
 
     public function setUp() :void
     {
         parent::setUp();
 
+        // This folder will reside in the orchestra sandbox environment
+        // placed at vendor/orchestra/testbench-core/laravel
+        $this->snipeFolder = base_path('vendor/drfraker/snipe-migrations/snapshots');
+
+        $this->snapshotFile = config('snipe.snapshot-location');
+        $this->snipeFile = config('snipe.snipefile-location');
+
+        // Reset state before each run
         $this->clearSnapshotDir();
+        $this->clearMigrationsDir();
+        $this->resetDatabaseState();
 
         $this->snipe = new Snipe();
     }
@@ -23,28 +55,47 @@ class SnipeMigrationsTest extends TestCase
     {
         $this->mimicInMemoryDatabase();
 
-        Artisan::ShouldReceive('call')->never();
+        Artisan::shouldReceive('call')->never();
 
         $this->snipe->importSnapshot();
     }
 
     protected function mimicInMemoryDatabase(): void
     {
-        config()->set('database.default', 'sqlite');
-        config()->set('database.connections.sqlite.database', ':memory:');
+        config()->set([
+            'database.default' => 'sqlite',
+            'database.connections.sqlite.database' => ':memory:',
+        ]);
     }
 
     protected function clearSnapshotDir()
     {
-        $snipefile = '../snapshots/.snipe';
-        $snapshot = '../snapshots/snipe_snapshot.sql';
-
-        if (file_exists($snipefile)) {
-            unlink($snipefile);
+        if (!is_dir($this->snipeFolder)) {
+            mkdir($this->snipeFolder, 0777, true);
+            return;
         }
 
-        if (file_exists($snapshot)) {
-            unlink($snapshot);
+        // Prepare sandbox for subsequent runs
+        if (file_exists($this->snipeFile)) {
+            $this->assertTrue(unlink($this->snipeFile));
         }
+
+        if (file_exists($this->snapshotFile)) {
+            $this->assertTrue(unlink($this->snapshotFile));
+        }
+    }
+
+    protected function clearMigrationsDir()
+    {
+        foreach (File::allFiles(database_path('migrations')) as $file) {
+            if ($file->getFilename() !== '.gitkeep') {
+                unlink($file->getRealPath());
+            }
+        }
+    }
+
+    protected function resetDatabaseState(): void
+    {
+        SnipeDatabaseState::$checkedForDatabaseFileChanges = false;
     }
 }

--- a/tests/SnipeMigrationsTest.php
+++ b/tests/SnipeMigrationsTest.php
@@ -31,7 +31,6 @@ class SnipeMigrationsTest extends TestCase
      */
     protected $snipeFile;
 
-
     public function setUp() :void
     {
         parent::setUp();
@@ -124,6 +123,7 @@ class SnipeMigrationsTest extends TestCase
     {
         if (! is_dir($this->snipeFolder)) {
             mkdir($this->snipeFolder, 0777, true);
+
             return;
         }
 

--- a/tests/SnipeMigrationsTest.php
+++ b/tests/SnipeMigrationsTest.php
@@ -60,6 +60,14 @@ class SnipeMigrationsTest extends TestCase
         $this->snipe->importSnapshot();
     }
 
+    /** @test */
+    public function it_calls_migration_commands_for_mysql_databases()
+    {
+        Artisan::shouldReceive('call')->with('migrate:fresh');
+
+        $this->snipe->importSnapshot();
+    }
+
     protected function mimicInMemoryDatabase(): void
     {
         config()->set([

--- a/tests/SnipeMigrationsTest.php
+++ b/tests/SnipeMigrationsTest.php
@@ -13,19 +13,19 @@ class SnipeMigrationsTest extends TestCase
     protected $snipe;
 
     /**
-     * The absolute path to the "snapshots" folder
-     * @var
+     * The absolute path to the "snapshots" folder.
+     * @var string
      */
     protected $snipeFolder;
 
     /**
-     * The full path to the snipe_snapshot.sql file
+     * The full path to the snipe_snapshot.sql file.
      * @var string
      */
     protected $snapshotFile;
 
     /**
-     * The full path to the .snip file
+     * The full path to the .snip file.
      * @var string
      */
     protected $snipeFile;
@@ -99,7 +99,7 @@ class SnipeMigrationsTest extends TestCase
 
     protected function clearSnapshotDir()
     {
-        if (!is_dir($this->snipeFolder)) {
+        if (! is_dir($this->snipeFolder)) {
             mkdir($this->snipeFolder, 0777, true);
             return;
         }


### PR DESCRIPTION
Users can now configure the exact path to the mysql and mysqldump binaries for different kind of set ups.

Closes https://github.com/drfraker/snipe-migrations/issues/28
Closes #27 

---

```
Code Coverage Report:    
  2019-09-27 12:13:33    
                         
 Summary:                
  Classes: 25.00% (1/4)  
  Methods: 63.16% (12/19)
  Lines:   57.65% (49/85)

\Drfraker\SnipeMigrations::Drfraker\SnipeMigrations\Snipe
  Methods:  66.67% (10/15)   Lines:  72.73% ( 40/ 55)
\Drfraker\SnipeMigrations::Drfraker\SnipeMigrations\SnipeMigrationsServiceProvider
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  9/  9)
```