### PR TITLE
Support Laravel 8 seeders path

### DIFF
--- a/src/Snipe.php
+++ b/src/Snipe.php
@@ -101,7 +101,7 @@ class Snipe
      */
     protected function seederFileTimeSum()
     {
-        return collect([database_path('seeds')])
+        return collect([$this->getSeederPath()])
             ->map(function ($path) {
                 return collect(File::allFiles($path))
                     ->sum(function ($file) {
@@ -142,6 +142,18 @@ class Snipe
 
             SnipeDatabaseState::$importedDatabase = true;
         }
+    }
+
+    /**
+     * Get the seeder folder path. 
+     *
+     * @return string
+     */
+    protected function getSeederPath(): string
+    {
+        $path = database_path('seeds');
+        
+        return is_dir($path) ? $path : database_path('seeders');
     }
 
     /**

--- a/src/Snipe.php
+++ b/src/Snipe.php
@@ -145,14 +145,14 @@ class Snipe
     }
 
     /**
-     * Get the seeder folder path. 
+     * Get the seeder folder path.
      *
      * @return string
      */
     protected function getSeederPath(): string
     {
         $path = database_path('seeds');
-        
+
         return is_dir($path) ? $path : database_path('seeders');
     }
 


### PR DESCRIPTION
This PR fixes the same issue as #38 but following laravel logic for seeds/seeders folders existence.

> This will break BC with 7.x and will break some old 8.x applications as the change from seeds to seeders is somewhat > optional. [Internally Laravel checks for both directories]>>(https://github.com/laravel/framework/blob/43bea00fd27c76c01fd009e46725a54885f4d2a5/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php#L71-L75).
>
> _Originally posted by @Vusys in https://github.com/drfraker/snipe-migrations/issues/38#issuecomment-732208179_

