### PR TITLE
PHP 8.0 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
+  - 8.0
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         }
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^7.1|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^8.0",
         "orchestra/testbench": "^3.7",
         "php-mock/php-mock-mockery": "^1.3"
     },


### PR DESCRIPTION
This pull requests adds:

* PHP 8 to the supported list of PHP versions in composer.json
* Upgrades PHPUnit from 7 to 8 (required for PHP 8)
* Adds PHP 7.4 and 8.0 tests to TravisCI